### PR TITLE
change package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='zcrmsdk-plus',
+    name='zcrmsdk',
     version='1.0.8',
 
     description='Zoho CRM SDK for Python developers',


### PR DESCRIPTION
Renaming of package in setup.py leads to import issues.
Get original name back.